### PR TITLE
Fixed repository website link

### DIFF
--- a/scripts/hub.me.js
+++ b/scripts/hub.me.js
@@ -96,12 +96,14 @@
     };
 
     Plugin.prototype.createRepo = function(repo) {
+        // test if homepage begins with http or https
+        repo.homepage = ( repo.homepage && !( /^(http|https):\/\//.test( repo.homepage ) ) ) ? "http://" + repo.homepage : repo.homepage;          
 
         var repository =    '<article>' +
                                 '<div>' +
                                     '<h2><a href="' + repo.html_url + '">' + repo.name + '</a></h2>' +
                                     '<p>' + repo.description + '</p>' +
-                                    '<a href="' + repo.homepage + '">' + repo.homepage + '</a>' +
+                                    '<a href="' + repo.homepage + '" target="_blank">' + repo.homepage + '</a>' +
                                 '</div>' +
                             '</article>'; 
 


### PR DESCRIPTION
Some websites doesn't have http or https.. so, this code fixes it.

see example:
http://clark-kent.github.com/ 

momentjs.com is bugged
