### PR TITLE
Ability to show or hide the languages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head> 
 	
 	<meta charset="utf-8"> 
-	<meta name = "viewport" content="width=device-width, maximum-scale=1">
+	<meta name="viewport" content="width=device-width, maximum-scale=1">
 
 	<title>my open source gallery</title>
 	<link id="default-css" rel="stylesheet" href="css/screen.css">
@@ -20,7 +20,7 @@
 		<img src="img/cat.png" alt="Github's Logo" />
 	</footer>
 
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
 	<script src="scripts/css3-mediaqueries.js"></script>
 	<script src="scripts/hub.me.js"></script>
 
@@ -28,7 +28,8 @@
 		$('body').hubMe({
 			'username': 'clark-kent', // you're not Clark Kent, right?
 			'theme': 'gray', // available themes: blue (default), black & gray
-			'exclude': ['wormz', 'cufon'] // exclude project by name
+			'exclude': ['wormz', 'cufon'], // exclude project by name
+			'languages': true // sort repos by languages true : false
 		});
 	</script>
 

--- a/scripts/hub.me.js
+++ b/scripts/hub.me.js
@@ -24,7 +24,8 @@
         defaults = {
             username: 'github',
             theme: 'blue',
-            exclude: []
+            exclude: [],
+            languages: true
         };
 
     // The actual plugin constructor
@@ -55,33 +56,32 @@
 
         var self = this,
         repos = [],
-        thisRepo = this.options.username + '.github.com';
+        thisRepo = self.options.username + '.github.com';
 
         $.getJSON('https://api.github.com/users/' + this.options.username + '/repos?callback=?', function (result) {
-            
-            $.each(result.data, function(i, field) {
-                if (field.language != null)
-                    repos.push(field);
+
+            $.each(result.data, function(i, field) {            
+            	if(field.language != null && field.name != thisRepo)
+					repos.push(field);
             });
-
+			
             repos = orderByLanguages(repos);
-
+			
             $.each(repos, function(i, field) {
                 
                 if ( $.inArray( repos[i].name, self.options.exclude ) === -1 ) {
-                
-                    if (i > 0) {
-                        if (repos[i].language != repos[i-1].language) {
-                            self.createCategory(repos[i].language);
-                        }
+                	if (self.options.languages) {
+	                    if (i > 0) {
+	                        if (repos[i].language != repos[i-1].language) {
+	                            self.createCategory(repos[i].language);
+	                        }
+	                    }
+	                    else {
+	                        self.createCategory(repos[i].language);
+	                    }
                     }
-                    else {
-                        self.createCategory(repos[i].language);
-                    }
-
-                    if (repos[i].name != thisRepo) {
-                        self.createRepo(repos[i]);
-                    }
+                    
+                    self.createRepo(repos[i]);
                 }
 
             });
@@ -94,7 +94,7 @@
         var cat =   '<section>' +
                         '<h1>' + catName + '</h1>' +
                     '</section>';
-
+		
         $(this.element).append(cat);
 
     };


### PR DESCRIPTION
I added an option of `languages` to show or hide the language sections and instead list out just the projects. The default is `true` so the example doesn't change, if set to `false` then it doesn't create the language sections.
