### PR TITLE
Change WTFPL inside project manifest to MIT

### DIFF
--- a/hub.me.jquery.json
+++ b/hub.me.jquery.json
@@ -20,8 +20,8 @@
   ],
   "licenses": [
     {
-      "type": "WTFPL",
-      "url": "http://www.wtfpl.net/"
+      "type": "MIT",
+      "url": "http://zenorocha.mit-license.org/"
     }
   ],
   "bugs": "https://github.com/zenorocha/hub.me/issues",


### PR DESCRIPTION
I assume MIT license is the correct license for this project as it's shown on README. Is that correct?
